### PR TITLE
Correct classes of objects detected inside other objects

### DIFF
--- a/utils/class_corrections.py
+++ b/utils/class_corrections.py
@@ -1,0 +1,84 @@
+import numpy as np
+import torch
+
+from utils.general import bbox_io1
+
+# Adjust class if io1 of contained class and container class >= threshold
+BBOX_IO1_THRESHOLD = 0.7
+# If A is inside B, then it becomes C
+CONTAINED_CLASS_MAPPING = {
+    # "brace cracked/broken"
+    0: {
+        12: 0,  # inside "entire brace" -> "brace cracked/broken"
+        13: 2,  # inside "entire crossarm" -> "crossarm cracked/broken"
+        14: 1,  # inside "entire pole" -> "cracked pole"
+    },
+    # "crossarm cracked/broken"
+    2: {
+        12: 0,  # inside "entire brace" -> "brace cracked/broken"
+        13: 2,  # inside "entire crossarm" -> "crossarm cracked/broken"
+        14: 1,  # inside "entire pole" -> "cracked pole"
+    },
+    # "cracked pole"
+    1: {
+        12: 0,  # inside "entire brace" -> "brace cracked/broken"
+        13: 2,  # inside "entire crossarm" -> "crossarm cracked/broken"
+        14: 1,  # inside "entire pole" -> "cracked pole"
+    },
+    # Testing with FPL model of AEP images
+    # "Polymer Insulator"
+    9: {
+        5: 8,  # inside "Steel Crossarm" -> "Polymer Dead-end Insulator"
+        19: 8,  # inside "Wood Pole" -> "Polymer Dead-end Insulator"
+    }
+}
+
+
+def get_corrected_class(cls, xyxy, det, names):
+    """
+    The class of a detected object could depend on whether it's found (mostly)
+    inside the bounding box of another object. Correct it if necessary.
+    """
+
+    # Is this class one of the ones that might be contained in bounding box of another class?
+    if int(cls) in CONTAINED_CLASS_MAPPING:
+
+        # Get just detections for the outer classes
+        # A detection has the format x, y, x, y, conf, class
+        mask = torch.as_tensor([int(elem) in CONTAINED_CLASS_MAPPING[int(cls)] for elem in det[:, 5]])
+        outer_classes_detections = det[mask]
+
+        # See if bounding box xyxy is (mostly) inside one of the outer_classes_boxes
+        if len(outer_classes_detections):
+            outer_classes_boxes = np.array(
+                [np.array(xyxy) for (*xyxy, conf, cls) in outer_classes_detections])
+            io1 = bbox_io1(xyxy, outer_classes_boxes)
+
+            # If it's somehow contained in multiple objects, use one that it's most inside of
+            values, indices = io1.max(0)
+
+            # Does the class need to be adjusted?
+            if values.item() >= BBOX_IO1_THRESHOLD:
+                # A detection has the format x, y, x, y, conf, class
+                outer_class = int(outer_classes_detections[indices.item()][5])
+                message = '{} detected inside {}'.format(names[int(cls)], names[int(outer_class)])
+
+                new_cls = torch.tensor(CONTAINED_CLASS_MAPPING[int(cls)][int(outer_class)])
+                if new_cls == cls:
+                    message += ': no change'
+                else:
+                    message += ': changing {} to {}'.format(names[int(cls)], names[int(new_cls)])
+                    cls = new_cls
+
+                print(message)
+
+    return cls
+
+
+def hide_container_object(cls):
+    """
+    If this class is one of the container objects that's used to correct the class of objects found inside it,
+    it should get hidden if desired
+    """
+    container_classes_keys = [list(CONTAINED_CLASS_MAPPING[key].keys()) for key in list(CONTAINED_CLASS_MAPPING.keys())]
+    return int(cls) in set(np.concatenate(container_classes_keys).flat)

--- a/utils/class_corrections.py
+++ b/utils/class_corrections.py
@@ -25,12 +25,18 @@ CONTAINED_CLASS_MAPPING = {
         13: 2,  # inside "entire crossarm" -> "crossarm cracked/broken"
         14: 1,  # inside "entire pole" -> "cracked pole"
     },
-    # Testing with FPL model of AEP images
-    # "Polymer Insulator"
+    # "rotten wood"
     9: {
-        5: 8,  # inside "Steel Crossarm" -> "Polymer Dead-end Insulator"
-        19: 8,  # inside "Wood Pole" -> "Polymer Dead-end Insulator"
-    }
+        12: 0,  # inside "entire brace" -> "brace cracked/broken"
+        13: 2,  # inside "entire crossarm" -> "crossarm cracked/broken"
+        14: 1,  # inside "entire pole" -> "cracked pole"
+    },
+    # # Testing with FPL model on AEP images
+    # # "Polymer Insulator"
+    # 9: {
+    #     5: 8,  # inside "Steel Crossarm" -> "Polymer Dead-end Insulator"
+    #     19: 8,  # inside "Wood Pole" -> "Polymer Dead-end Insulator"
+    # }
 }
 
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -460,6 +460,23 @@ def bbox_iou(box1, box2, x1y1x2y2=True, GIoU=False, DIoU=False, CIoU=False, eps=
         return iou  # IoU
 
 
+def bbox_io1(box, boxes):
+    boxes = boxes.T
+    xA = np.maximum(box[0], boxes[0])
+    yA = np.maximum(box[1], boxes[1])
+    xB = np.minimum(box[2], boxes[2])
+    yB = np.minimum(box[3], boxes[3])
+
+    interW = xB - xA
+    interH = yB - yA
+    z = (interW > 0) * (interH > 0)
+    interArea = z * interW * interH
+
+    boxAArea = (box[2] - box[0]) * (box[3] - box[1])
+    io1 = interArea / boxAArea
+    return io1
+
+
 def box_iou(box1, box2):
     # https://github.com/pytorch/vision/blob/master/torchvision/ops/boxes.py
     """


### PR DESCRIPTION
Classes of certain detected objects can depend on what other objects they're inside. For example, if a "cracked pole" is detected inside a "crossarm", then change the class to "cracked crossarm". 

I added the following opts to `detect.py`:
- `--correct-classes` for indicating if class corrections need to be done
- `--hide-containers` for indicating if the "container" objects should be hidden from marked up images or generated text labels  (ignored if `--correct-classes` not used) 

This is quick and dirty, so the class mappings are defined in `class_corrections.py` instead of in a settings file somewhere.